### PR TITLE
Page has both vertical/horizontal scrollbars

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,7 +8,6 @@ import LogoHover from './logo_hover.svg'
 const Header = styled.header`
   display: flex;
   justify-content: center;
-  width: 100vw;
 `
 
 const HeaderContainer = styled.div`


### PR DESCRIPTION
On Chrome version 67.0.3396.87 (Official Build) (64-bit), the `width: 100vw;` creates scrollbars for some reasons. There might be a better way to address this

![image](https://user-images.githubusercontent.com/1778633/41655735-0e44c792-74b8-11e8-833b-cfbcf0274ffc.png)
